### PR TITLE
build: add module exporting

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ pub fn build(b: *Builder) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("zig-rlp", Builder.CreateModuleOptions{ .source_file = .{ .path = "src/main.zig" } });
+    _ = b.addModule("rlp", Builder.CreateModuleOptions{ .source_file = .{ .path = "src/main.zig" } });
 
     const lib = b.addStaticLibrary(.{
         .name = "zig-rlp",

--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,9 @@ const Builder = @import("std").build.Builder;
 pub fn build(b: *Builder) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
+    _ = b.addModule("zig-rlp", Builder.CreateModuleOptions{ .source_file = .{ .path = "src/main.zig" } });
+
     const lib = b.addStaticLibrary(.{
         .name = "zig-rlp",
         .root_source_file = .{ .path = "src/main.zig" },


### PR DESCRIPTION
Declares an exported module so other packages can import it via the new Zig package manager:

For general documentation on how this works, see the [v0.11.0 release notes](https://ziglang.org/download/0.11.0/release-notes.html#Package-Management).