### PR TITLE
Empty fields at end of struct

### DIFF
--- a/src/deserialize.zig
+++ b/src/deserialize.zig
@@ -291,3 +291,20 @@ test "deserialize an optional" {
     _ = try deserialize(?u32, list.items, &z);
     try expect(z.? == x.?);
 }
+
+test "deserialize a structure with missing optional fields at the end" {
+    const structWithTrailingOptionalFields = struct {
+        x: u64,
+        y: ?u64,
+        z: ?u64,
+        alpha: ?[]const u8,
+    };
+    const serialized = [_]u8{ 0xc6, 0x84, 0xde, 0xad, 0xbe, 0xef, 5 };
+
+    var mystruct: structWithTrailingOptionalFields = undefined;
+    _ = try deserialize(structWithTrailingOptionalFields, serialized[0..], &mystruct);
+    try expect(mystruct.x == 0xdeadbeef);
+    try expect(mystruct.y != null and mystruct.y.? == 5);
+    try expect(mystruct.z == null);
+    try expect(mystruct.alpha == null);
+}


### PR DESCRIPTION
In zig, the `Optional` type can be used to add fields at the end of structures to describe the evolution of that structure over time. A prime example is the Ethereum block, to which fields are added as forks occur.

The issue that arises, is when a payload serialized with an older version of the structure needs to be deserialized with the new version of that structure. To allow for this, we do not raise an error condition if the field being currently deserialized is an `Optional` and the serialized buffer we are reading from has no more available bytes. In this case, the `Optional` field will be set to `null`.