### PR TITLE
add a failing test that should pass

### DIFF
--- a/src/deserialize.zig
+++ b/src/deserialize.zig
@@ -374,3 +374,11 @@ test "access list empty" {
     var out: StrippedTxn = undefined;
     _ = try deserialize(StrippedTxn, rlp, &out);
 }
+
+test "deserialize a byte slice" {
+    var buf: [128]u8 = undefined;
+    const rlp = try std.fmt.hexToBytes(&buf, "f7940000000000000000000000000000000000001210");
+    var out: []u8 = undefined;
+
+    _ = try deserialize([]const u8, rlp, &out);
+}

--- a/src/deserialize.zig
+++ b/src/deserialize.zig
@@ -377,8 +377,9 @@ test "access list empty" {
 
 test "deserialize a byte slice" {
     var buf: [128]u8 = undefined;
-    const rlp = try std.fmt.hexToBytes(&buf, "f7940000000000000000000000000000000000001210");
-    var out: []u8 = undefined;
+    const rlp = try std.fmt.hexToBytes(&buf, "940000000000000000000000000000000000001210");
+    var out = [_]u8{0} ** 20;
+    var out_: []u8 = out[0..];
 
-    _ = try deserialize([]const u8, rlp, &out);
+    const deserialized = try deserialize([]const u8, rlp, &out_);
 }


### PR DESCRIPTION
This is a test similar to the one in #9, that illustrates the same problem but for simpler bytes structures.

The problem is that an allocation isn't warranted here because the data already exists and we should just make a reference to it instead of allocating it. But that might be a DX nightmare since now there is a reference to whatever passed the RLP. Just thinking out loud here, I don't know what is the best approach yet.