### PR TITLE
Support list of complex types

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -327,7 +327,7 @@ test "access list filled" {
 
     var buf: [128]u8 = undefined;
     const rlp = try std.fmt.hexToBytes(&buf, "f83af838f7940000000000000000000000000000000000001210e1a00000000000000000000000000000000000000000000000000000000000000203");
-    var out: StrippedTxn = StrippedTxn{ .access_list = &[0]AccessListItem{} };
+    var out: StrippedTxn = undefined; // StrippedTxn{ .access_list = &[0]AccessListItem{} };
     _ = try deserialize(StrippedTxn, rlp, &out, testing.allocator);
 
     const expected_address = [_]u8{0} ** 18 ++ [_]u8{ 0x12, 0x10 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -328,5 +328,14 @@ test "access list filled" {
     var buf: [128]u8 = undefined;
     const rlp = try std.fmt.hexToBytes(&buf, "f83af838f7940000000000000000000000000000000000001210e1a00000000000000000000000000000000000000000000000000000000000000203");
     var out: StrippedTxn = StrippedTxn{ .access_list = &[0]AccessListItem{} };
-    _ = try deserialize(StrippedTxn, rlp, &out);
+    _ = try deserialize(StrippedTxn, rlp, &out, testing.allocator);
+
+    const expected_address = [_]u8{0} ** 18 ++ [_]u8{ 0x12, 0x10 };
+    try testing.expectEqual(out.access_list[0].address, expected_address);
+
+    const expected_access = [_]u8{0} ** 30 ++ [_]u8{ 2, 3 };
+    try testing.expectEqual(out.access_list[0].storage_keys[0], expected_access);
+
+    testing.allocator.free(out.access_list[0].storage_keys);
+    testing.allocator.free(out.access_list);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -327,7 +327,7 @@ test "access list filled" {
 
     var buf: [128]u8 = undefined;
     const rlp = try std.fmt.hexToBytes(&buf, "f83af838f7940000000000000000000000000000000000001210e1a00000000000000000000000000000000000000000000000000000000000000203");
-    var out: StrippedTxn = undefined; // StrippedTxn{ .access_list = &[0]AccessListItem{} };
+    var out: StrippedTxn = undefined;
     _ = try deserialize(StrippedTxn, rlp, &out, testing.allocator);
 
     const expected_address = [_]u8{0} ** 18 ++ [_]u8{ 0x12, 0x10 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -315,3 +315,18 @@ test "zero" {
     try serialize(u8, std.testing.allocator, 0, &out);
     try std.testing.expectEqualSlices(u8, &[_]u8{0x80}, out.items);
 }
+
+test "access list filled" {
+    const AccessListItem = struct {
+        address: [20]u8,
+        storage_keys: [][32]u8,
+    };
+    const StrippedTxn = struct {
+        access_list: []AccessListItem,
+    };
+
+    var buf: [128]u8 = undefined;
+    const rlp = try std.fmt.hexToBytes(&buf, "f83af838f7940000000000000000000000000000000000001210e1a00000000000000000000000000000000000000000000000000000000000000203");
+    var out: StrippedTxn = StrippedTxn{ .access_list = &[0]AccessListItem{} };
+    _ = try deserialize(StrippedTxn, rlp, &out);
+}


### PR DESCRIPTION
Fix for #9 . It's unfortunately not really practical to figure out when a slice has been pre-allocated so we allocate the slice regardless. I don't quite like it, but if I can't tell if a slice has been allocated or is `undefined` the safer approach is to always allocate.