### PR TITLE
support deserialization of single pointers (One type)

### DIFF
--- a/src/deserialize.zig
+++ b/src/deserialize.zig
@@ -156,10 +156,7 @@ pub fn deserialize(comptime T: type, serialized: []const u8, out: *T, allocator:
             },
             .One => {
                 out.* = try allocator.create(ptr.child);
-                const r = try sizeAndDataOffset(serialized);
-                var end = r.offset + r.size;
-                _ = try deserialize(ptr.child, serialized[r.offset..end], out.*, allocator);
-                return end;
+                return deserialize(ptr.child, serialized, out.*, allocator);
             },
             // TODO missing: Many, C
             else => return error.UnSupportedType,
@@ -402,4 +399,5 @@ test "deserialize a pointer to an integer" {
     var out: *u256 = undefined;
     _ = try deserialize(*u256, &rlp, &out, std.testing.allocator);
     defer std.testing.allocator.destroy(out);
+    _ = try std.testing.expectEqual(out.*, 0x0102030405060708090a);
 }


### PR DESCRIPTION
So far, only slices were supported as a pointer type, but since we now have to use the allocator, more pointer types can be supported when deserializing. This PR supports the `One` pointer type.