### PR TITLE
serialization: fix one byte slice encoding

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -109,7 +109,9 @@ pub fn serialize(comptime T: type, allocator: Allocator, data: T, list: *ArrayLi
                 .Slice => {
                     // Simple case: string
                     if (@sizeOf(ptr.child) == 1) {
-                        try list.append(128 + @as(u8, @truncate(data.len)));
+                        if (data.len != 1) {
+                            try list.append(128 + @as(u8, @truncate(data.len)));
+                        }
                         _ = try list.writer().write(data);
                     } else {
                         var tlist = ArrayList(u8).init(allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -339,3 +339,12 @@ test "access list filled" {
     testing.allocator.free(out.access_list[0].storage_keys);
     testing.allocator.free(out.access_list);
 }
+
+test "one byte slice" {
+    var out = ArrayList(u8).init(testing.allocator);
+    defer out.deinit();
+    const bytes = [_]u8{0x00};
+
+    try serialize([]const u8, std.testing.allocator, &bytes, &out);
+    try std.testing.expectEqualSlices(u8, &[_]u8{0x00}, out.items);
+}


### PR DESCRIPTION
This PR fixes a border case where single byte slices should be encoded as a single byte, and not as a string with length 1 (which uses one extra bytes).

I found this by comparing the serialization of this library and geth, for a block with `extraData = []byte{0x00}`. This library encoded this as `8100` and should be `00`.