### PR TITLE
Custom encoder/decoder must receive allocator

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2,14 +2,15 @@ const std = @import("std");
 const testing = std.testing;
 const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
-pub const deserialize = @import("deserialize.zig").deserialize;
 const hasFn = std.meta.trait.hasFn;
 
 const implementsRLP = hasFn("encodeToRLP");
 
+pub const deserialize = @import("deserialize.zig").deserialize;
+
 pub fn serialize(comptime T: type, allocator: Allocator, data: T, list: *ArrayList(u8)) !void {
     if (comptime implementsRLP(T)) {
-        return data.encodeToRLP(list);
+        return data.encodeToRLP(allocator, list);
     }
     const info = @typeInfo(T);
     return switch (info) {
@@ -136,7 +137,7 @@ pub fn serialize(comptime T: type, allocator: Allocator, data: T, list: *ArrayLi
                     }
                 },
                 .One => {
-                    try serialize(ptr.child, data.*, list);
+                    try serialize(ptr.child, allocator, data.*, list);
                 },
                 else => return error.UnsupportedType,
             }
@@ -283,7 +284,8 @@ const RLPEncodablePerson = struct {
     name: []const u8,
     age: u8,
 
-    pub fn encodeToRLP(self: RLPEncodablePerson, list: *ArrayList(u8)) !void {
+    pub fn encodeToRLP(self: RLPEncodablePerson, allocator: Allocator, list: *ArrayList(u8)) !void {
+        _ = allocator;
         _ = self;
         return list.append(42);
     }
@@ -328,7 +330,7 @@ test "access list filled" {
     var buf: [128]u8 = undefined;
     const rlp = try std.fmt.hexToBytes(&buf, "f83af838f7940000000000000000000000000000000000001210e1a00000000000000000000000000000000000000000000000000000000000000203");
     var out: StrippedTxn = undefined;
-    _ = try deserialize(StrippedTxn, rlp, &out, testing.allocator);
+    _ = try deserialize(StrippedTxn, testing.allocator, rlp, &out);
 
     const expected_address = [_]u8{0} ** 18 ++ [_]u8{ 0x12, 0x10 };
     try testing.expectEqual(out.access_list[0].address, expected_address);


### PR DESCRIPTION
This PR makes the following changes:
- It makes the custom encoder and decoder receive an allocator. This is required since both encoding and decoding need an allocator thus custom ones need one too. (i.e: _the same_ allocator, so all allocations in potentially nested structs with custom allocators be allocator-coherent).
- Move the serialize/deserialize parameters such that the `allocator : Allocator` is the first parameter, since this is a usual Zig idiom.