### PR TITLE
serialization: support dynamic RLP types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,66 +2,65 @@ name: Lint and test
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Zig
-      uses: korandoru/setup-zig@v1
-      with:
-        zig-version: 0.11.0
+      - name: Set up Zig
+        uses: korandoru/setup-zig@v1
+        with:
+          zig-version: 0.12.0
 
-    - name: Display zig compiler version
-      run:  zig version
+      - name: Display zig compiler version
+        run: zig version
 
-    - name: Build
-      run: zig build
+      - name: Build
+        run: zig build
 
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Zig
-      uses: korandoru/setup-zig@v1
-      with:
-        zig-version: 0.11.0
+      - name: Set up Zig
+        uses: korandoru/setup-zig@v1
+        with:
+          zig-version: 0.12.0
 
-    - name: Lint
-      run: zig fmt --check src/*.zig
+      - name: Lint
+        run: zig fmt --check src/*.zig
 
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Zig
-      uses: korandoru/setup-zig@v1
-      with:
-        zig-version: 0.11.0
+      - name: Set up Zig
+        uses: korandoru/setup-zig@v1
+        with:
+          zig-version: 0.12.0
 
-    - name: Test
-      run: zig build test --summary all
+      - name: Test
+        run: zig build test --summary all
 
   test-be:
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-    - name: Set up Zig
-      uses: korandoru/setup-zig@v1
-      with:
-        zig-version: 0.11.0
+      - name: Set up Zig
+        uses: korandoru/setup-zig@v1
+        with:
+          zig-version: 0.12.0
 
-    - name: Test
-      run: zig build test --summary all -fqemu -Dtarget=mips64-linux
+      - name: Test
+        run: zig build test --summary all -fqemu -Dtarget=mips64-linux

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # zig-rlp
 A zig implementation of RLP
 
-⚠️ Minimum-supported compiler version: ziglang's `0.11.0`
+⚠️ Minimum-supported compiler version: ziglang's `0.12.0`

--- a/src/main.zig
+++ b/src/main.zig
@@ -402,7 +402,7 @@ test "one byte slicei with value > 128" {
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x81, 0xff }, out.items);
 }
 
-test "generic rlp" {
+test "raw rlp" {
     const allocator = std.testing.allocator;
     {
         var out_generic = ArrayList(u8).init(allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -158,6 +158,22 @@ pub fn serialize(comptime T: type, allocator: Allocator, data: T, list: *ArrayLi
     };
 }
 
+const GenericRLPValue = union(enum) {
+    value: []const u8,
+    list: []const GenericRLPValue,
+
+    pub fn encodeToRLP(self: GenericRLPValue, allocator: Allocator, list: *std.ArrayList(u8)) !void {
+        return switch (self) {
+            .value => |v| {
+                try serialize([]const u8, allocator, v, list);
+            },
+            .list => |v| {
+                try serialize([]const GenericRLPValue, allocator, v, list);
+            },
+        };
+    }
+};
+
 test "serialize an integer" {
     var list = ArrayList(u8).init(testing.allocator);
     defer list.deinit();
@@ -379,4 +395,13 @@ test "one byte slicei with value > 128" {
 
     try serialize([]const u8, std.testing.allocator, &bytes, &out);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x81, 0xff }, out.items);
+}
+
+test "generic rlp" {
+    var allocator = std.testing.allocator;
+    var out = ArrayList(u8).init(allocator);
+    defer out.deinit();
+
+    var foo: GenericRLPValue = .{ .value = "hello" };
+    try serialize(GenericRLPValue, allocator, foo, &out);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,7 +14,12 @@ fn writeLengthLength(length: usize, list: *ArrayList(u8)) !u8 {
     return @as(u8, @intCast(enc_length.len));
 }
 
-pub fn serialize(comptime T: type, allocator: Allocator, data: T, list: *ArrayList(u8)) !void {
+const SerializationError = error{
+    UnsupportedType,
+    OutOfMemory,
+};
+
+pub fn serialize(comptime T: type, allocator: Allocator, data: T, list: *ArrayList(u8)) SerializationError!void {
     if (comptime hasFn(T, "encodeToRLP")) {
         return data.encodeToRLP(allocator, list);
     }
@@ -399,9 +404,53 @@ test "one byte slicei with value > 128" {
 
 test "generic rlp" {
     var allocator = std.testing.allocator;
-    var out = ArrayList(u8).init(allocator);
-    defer out.deinit();
+    {
+        var out_generic = ArrayList(u8).init(allocator);
+        defer out_generic.deinit();
+        var generic: GenericRLPValue = .{ .value = "hello" };
+        try serialize(GenericRLPValue, allocator, generic, &out_generic);
 
-    var foo: GenericRLPValue = .{ .value = "hello" };
-    try serialize(GenericRLPValue, allocator, foo, &out);
+        var out = ArrayList(u8).init(allocator);
+        defer out.deinit();
+        const normal = "hello";
+        try serialize([]const u8, allocator, normal, &out);
+
+        try std.testing.expectEqualSlices(u8, out.items, out_generic.items);
+    }
+    {
+        var out_generic = ArrayList(u8).init(allocator);
+        defer out_generic.deinit();
+        var generic: GenericRLPValue = .{ .list = &[_]GenericRLPValue{ .{ .value = "hello" }, .{ .value = "world" } } };
+        try serialize(GenericRLPValue, allocator, generic, &out_generic);
+
+        var out = ArrayList(u8).init(allocator);
+        defer out.deinit();
+        var normal = [_][]const u8{ "hello", "world" };
+        try serialize([]const []const u8, allocator, &normal, &out);
+
+        try std.testing.expectEqualSlices(u8, out.items, out_generic.items);
+    }
+    {
+        var out_generic = ArrayList(u8).init(allocator);
+        defer out_generic.deinit();
+        var generic: GenericRLPValue = .{
+            .list = &[_]GenericRLPValue{
+                .{ .value = "hello" },
+                .{ .value = "world" },
+                .{ .list = &[_]GenericRLPValue{.{ .value = "nested" }} },
+            },
+        };
+        try serialize(GenericRLPValue, allocator, generic, &out_generic);
+
+        var out = ArrayList(u8).init(allocator);
+        defer out.deinit();
+        var normal: struct { a: []const u8, b: []const u8, c: []const []const u8 } = .{
+            .a = "hello",
+            .b = "world",
+            .c = &[_][]const u8{"nested"},
+        };
+        try serialize(@TypeOf(normal), allocator, normal, &out);
+
+        try std.testing.expectEqualSlices(u8, out.items, out_generic.items);
+    }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -163,17 +163,17 @@ pub fn serialize(comptime T: type, allocator: Allocator, data: T, list: *ArrayLi
     };
 }
 
-const GenericRLPValue = union(enum) {
+const RawRLPValue = union(enum) {
     value: []const u8,
-    list: []const GenericRLPValue,
+    list: []const RawRLPValue,
 
-    pub fn encodeToRLP(self: GenericRLPValue, allocator: Allocator, list: *std.ArrayList(u8)) !void {
+    pub fn encodeToRLP(self: RawRLPValue, allocator: Allocator, list: *std.ArrayList(u8)) !void {
         return switch (self) {
             .value => |v| {
                 try serialize([]const u8, allocator, v, list);
             },
             .list => |v| {
-                try serialize([]const GenericRLPValue, allocator, v, list);
+                try serialize([]const RawRLPValue, allocator, v, list);
             },
         };
     }
@@ -407,8 +407,8 @@ test "generic rlp" {
     {
         var out_generic = ArrayList(u8).init(allocator);
         defer out_generic.deinit();
-        var generic: GenericRLPValue = .{ .value = "hello" };
-        try serialize(GenericRLPValue, allocator, generic, &out_generic);
+        var generic: RawRLPValue = .{ .value = "hello" };
+        try serialize(RawRLPValue, allocator, generic, &out_generic);
 
         var out = ArrayList(u8).init(allocator);
         defer out.deinit();
@@ -420,8 +420,8 @@ test "generic rlp" {
     {
         var out_generic = ArrayList(u8).init(allocator);
         defer out_generic.deinit();
-        var generic: GenericRLPValue = .{ .list = &[_]GenericRLPValue{ .{ .value = "hello" }, .{ .value = "world" } } };
-        try serialize(GenericRLPValue, allocator, generic, &out_generic);
+        var generic: RawRLPValue = .{ .list = &[_]RawRLPValue{ .{ .value = "hello" }, .{ .value = "world" } } };
+        try serialize(RawRLPValue, allocator, generic, &out_generic);
 
         var out = ArrayList(u8).init(allocator);
         defer out.deinit();
@@ -433,14 +433,14 @@ test "generic rlp" {
     {
         var out_generic = ArrayList(u8).init(allocator);
         defer out_generic.deinit();
-        var generic: GenericRLPValue = .{
-            .list = &[_]GenericRLPValue{
+        var generic: RawRLPValue = .{
+            .list = &[_]RawRLPValue{
                 .{ .value = "hello" },
                 .{ .value = "world" },
-                .{ .list = &[_]GenericRLPValue{.{ .value = "nested" }} },
+                .{ .list = &[_]RawRLPValue{.{ .value = "nested" }} },
             },
         };
-        try serialize(GenericRLPValue, allocator, generic, &out_generic);
+        try serialize(RawRLPValue, allocator, generic, &out_generic);
 
         var out = ArrayList(u8).init(allocator);
         defer out.deinit();

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,7 +14,7 @@ fn writeLengthLength(length: usize, list: *ArrayList(u8)) !u8 {
     return @as(u8, @intCast(enc_length.len));
 }
 
-const SerializationError = error{
+pub const SerializationError = error{
     UnsupportedType,
     OutOfMemory,
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -403,11 +403,11 @@ test "one byte slicei with value > 128" {
 }
 
 test "generic rlp" {
-    var allocator = std.testing.allocator;
+    const allocator = std.testing.allocator;
     {
         var out_generic = ArrayList(u8).init(allocator);
         defer out_generic.deinit();
-        var generic: RawRLPValue = .{ .value = "hello" };
+        const generic: RawRLPValue = .{ .value = "hello" };
         try serialize(RawRLPValue, allocator, generic, &out_generic);
 
         var out = ArrayList(u8).init(allocator);
@@ -420,7 +420,7 @@ test "generic rlp" {
     {
         var out_generic = ArrayList(u8).init(allocator);
         defer out_generic.deinit();
-        var generic: RawRLPValue = .{ .list = &[_]RawRLPValue{ .{ .value = "hello" }, .{ .value = "world" } } };
+        const generic: RawRLPValue = .{ .list = &[_]RawRLPValue{ .{ .value = "hello" }, .{ .value = "world" } } };
         try serialize(RawRLPValue, allocator, generic, &out_generic);
 
         var out = ArrayList(u8).init(allocator);
@@ -433,7 +433,7 @@ test "generic rlp" {
     {
         var out_generic = ArrayList(u8).init(allocator);
         defer out_generic.deinit();
-        var generic: RawRLPValue = .{
+        const generic: RawRLPValue = .{
             .list = &[_]RawRLPValue{
                 .{ .value = "hello" },
                 .{ .value = "world" },
@@ -444,7 +444,7 @@ test "generic rlp" {
 
         var out = ArrayList(u8).init(allocator);
         defer out.deinit();
-        var normal: struct { a: []const u8, b: []const u8, c: []const []const u8 } = .{
+        const normal: struct { a: []const u8, b: []const u8, c: []const []const u8 } = .{
             .a = "hello",
             .b = "world",
             .c = &[_][]const u8{"nested"},


### PR DESCRIPTION
See https://github.com/jsign/phant/pull/27 first and for context.

This PR adds support for a `GenericRLPValue` which allow to construct values at runtime.