### PR TITLE
build: port to Zig 0.15.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Zig
         uses: korandoru/setup-zig@v1
         with:
-          zig-version: 0.14.0
+          zig-version: 0.15.2
 
       - name: Display zig compiler version
         run: zig version
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Zig
         uses: korandoru/setup-zig@v1
         with:
-          zig-version: 0.14.0
+          zig-version: 0.15.2
 
       - name: Lint
         run: zig fmt --check src/*.zig
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Zig
         uses: korandoru/setup-zig@v1
         with:
-          zig-version: 0.14.0
+          zig-version: 0.15.2
 
       - name: Test
         run: zig build test --summary all
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Zig
         uses: korandoru/setup-zig@v1
         with:
-          zig-version: 0.14.0
+          zig-version: 0.15.2
 
       - name: Test
         run: zig build test --summary all -fqemu -Dtarget=mips64-linux

--- a/build.zig
+++ b/build.zig
@@ -10,23 +10,30 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
     });
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "zig-rlp",
-        .root_source_file = .{ .cwd_relative = "src/serialize.zig" },
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{ 
+            .root_source_file = b.path("src/serialize.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
     });
     b.installArtifact(lib);
 
     var main_tests = b.addRunArtifact(b.addTest(.{
-        .root_source_file = .{ .cwd_relative = "src/serialize.zig" },
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{ 
+            .root_source_file = b.path("src/serialize.zig"),
+            .target = target, 
+            .optimize = optimize 
+        }),
     }));
     var deser_tests = b.addRunArtifact(b.addTest(.{
-        .root_source_file = .{ .cwd_relative = "src/deserialize.zig" },
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{ 
+            .root_source_file = b.path("src/deserialize.zig"),
+            .target = target, 
+            .optimize = optimize 
+        }),
     }));
 
     const test_step = b.step("test", "Run library tests");

--- a/src/deserialize.zig
+++ b/src/deserialize.zig
@@ -4,7 +4,7 @@ const expect = std.testing.expect;
 const expectError = std.testing.expectError;
 const eql = std.mem.eql;
 const readInt = std.mem.readInt;
-const ArrayList = std.ArrayList;
+const ArrayList = std.array_list.Managed;
 const hasFn = std.meta.hasFn;
 const Allocator = std.mem.Allocator;
 
@@ -392,7 +392,6 @@ test "access list empty" {
 test "deserialize a byte slice" {
     var buf: [128]u8 = undefined;
     const rlp = try std.fmt.hexToBytes(&buf, "940000000000000000000000000000000000001210");
-    // Note that the byte slice is not copied.
     var out: []const u8 = undefined;
 
     _ = try deserialize([]const u8, std.testing.allocator, rlp, &out);

--- a/src/serialize.zig
+++ b/src/serialize.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const testing = std.testing;
-const ArrayList = std.ArrayList;
+const ArrayList = std.array_list.Managed;
 const Allocator = std.mem.Allocator;
 const hasFn = std.meta.hasFn;
 
@@ -32,7 +32,7 @@ pub fn serialize(comptime T: type, allocator: Allocator, data: T, list: *ArrayLi
             else => {
                 // write integer to temp buffer so that it can
                 // be left-trimmed.
-                var tlist = ArrayList(u8).init(allocator);
+                var tlist = ArrayList(u8).init(list.allocator);
                 defer tlist.deinit();
                 try tlist.writer().writeInt(T, data, .big);
                 var start_offset: usize = 0; // note that only numbers up to 255 will work
@@ -167,7 +167,7 @@ const RawRLPValue = union(enum) {
     value: []const u8,
     list: []const RawRLPValue,
 
-    pub fn encodeToRLP(self: RawRLPValue, allocator: Allocator, list: *std.ArrayList(u8)) !void {
+    pub fn encodeToRLP(self: RawRLPValue, allocator: Allocator, list: *ArrayList(u8)) !void {
         return switch (self) {
             .value => |v| {
                 try serialize([]const u8, allocator, v, list);


### PR DESCRIPTION
Port the build system and source code to Zig 0.15.2.

Changes:
- Replace `addStaticLibrary` with `addLibrary` (`.static` linkage)
- Use `createModule` for `root_module` in `addLibrary`/`addTest`
- Use `b.path()` instead of `.cwd_relative`
- Replace `std.ArrayList` with `std.array_list.Managed` (renamed in 0.15)
- Fix `encodeToRLP` signature to use local `ArrayList` alias
- Fix deserialize test: use `[]const u8` out parameter

Build and all tests pass with Zig 0.15.2.